### PR TITLE
adding switching method to the end of the addToList method in the Det…

### DIFF
--- a/ShoppIt/src/main/controllers/DetailedItemPopUpController.java
+++ b/ShoppIt/src/main/controllers/DetailedItemPopUpController.java
@@ -6,6 +6,7 @@ import java.util.ResourceBundle;
 import database.models.FoodItem;
 import database.models.Item;
 import helpers.InfoStore;
+import helpers.ScreenHandler;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -54,6 +55,7 @@ public class DetailedItemPopUpController{
 		
 		stage = (Stage) detailedItemGridPane.getScene().getWindow();
 		stage.close();
+		ScreenHandler.changeTo("newListScene");
 	}
 	
 	//Method that controls exit button - closes the popup


### PR DESCRIPTION
#74 completed
Added a line of code that allows the scene to be switched when the add to list button is pressed. Uses the internal ScreenHandler.changeTo() method. Changing the scene in this way may change the way we approach the issue of sending information to the newList scene.