### PR TITLE
Window resize responsive Closes issue #73

### DIFF
--- a/ShoppIt/src/main/application/Main.java
+++ b/ShoppIt/src/main/application/Main.java
@@ -16,11 +16,8 @@ public class Main extends Application {
 		try {
 			Scene scene = new Scene(new Pane());
 			scene.getStylesheets().add(getClass().getResource("/css/application.css").toExternalForm());
-			// scene.getStylesheets().add("https://fonts.googleapis.com/css2?family=Fredoka+One");
-
 			setScreens(scene);
-
-			// primaryStage.setResizable(false);
+			
 			primaryStage.setTitle("ShoppIt");
 			primaryStage.setScene(scene);
 			primaryStage.setMinHeight(700);

--- a/ShoppIt/src/main/application/Main.java
+++ b/ShoppIt/src/main/application/Main.java
@@ -14,7 +14,7 @@ public class Main extends Application {
 	public void start(Stage primaryStage) {
 
 		try {
-			Scene scene = new Scene(new Pane(), 800, 600);
+			Scene scene = new Scene(new Pane());
 			scene.getStylesheets().add(getClass().getResource("/css/application.css").toExternalForm());
 			// scene.getStylesheets().add("https://fonts.googleapis.com/css2?family=Fredoka+One");
 
@@ -23,6 +23,8 @@ public class Main extends Application {
 			// primaryStage.setResizable(false);
 			primaryStage.setTitle("ShoppIt");
 			primaryStage.setScene(scene);
+			primaryStage.setMinHeight(700);
+			primaryStage.setMinWidth(800);
 			primaryStage.show();
 
 		} catch (Exception e) {

--- a/ShoppIt/src/resources/fxml/IndividualListScene.fxml
+++ b/ShoppIt/src/resources/fxml/IndividualListScene.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="840.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.IndividualListSceneController">
+<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.IndividualListSceneController">
    <center>
       <GridPane BorderPane.alignment="CENTER">
         <columnConstraints>

--- a/ShoppIt/src/resources/fxml/Main.fxml
+++ b/ShoppIt/src/resources/fxml/Main.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
 
-<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="840.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.MainController">
+<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.MainController">
    <center>
       <GridPane opacity="0.61" BorderPane.alignment="CENTER">
         <columnConstraints>

--- a/ShoppIt/src/resources/fxml/NewListScene.fxml
+++ b/ShoppIt/src/resources/fxml/NewListScene.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="840.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.NewListSceneController">
+<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.NewListSceneController">
    <center>
       <GridPane BorderPane.alignment="CENTER">
         <columnConstraints>

--- a/ShoppIt/src/resources/fxml/SearchPopUpScene.fxml
+++ b/ShoppIt/src/resources/fxml/SearchPopUpScene.fxml
@@ -10,7 +10,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 
-<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.SearchPopUpController">
+<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0" prefWidth="800.0" xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controllers.SearchPopUpController">
    <center>
       <GridPane fx:id="searchGridPane" BorderPane.alignment="CENTER">
         <columnConstraints>


### PR DESCRIPTION
Buttons now all appear within the window when opening the application. Window has a set minimum value to prevent squashing of the elements within the screen and no set maximum allowing them to still make it full screen. Minimum dimensions were added within the code so changes to this may be required in the future.
