### PR TITLE
JPQL Refactor - narrow down query methods (Closes #100)

### DIFF
--- a/ShoppIt/src/main/controllers/DetailedItemPopUpController.java
+++ b/ShoppIt/src/main/controllers/DetailedItemPopUpController.java
@@ -51,6 +51,9 @@ public class DetailedItemPopUpController{
 	public void addToList(ActionEvent event) {
 		InfoStore infoStore = InfoStore.getInstance();
 		Item currentItem = new Item(1,item.getId());
+
+		//adds the item to the list instance
+		infoStore.getList().add(currentItem);
 		
 		stage = (Stage) detailedItemGridPane.getScene().getWindow();
 		stage.close();

--- a/ShoppIt/src/main/controllers/DetailedItemPopUpController.java
+++ b/ShoppIt/src/main/controllers/DetailedItemPopUpController.java
@@ -51,9 +51,6 @@ public class DetailedItemPopUpController{
 	public void addToList(ActionEvent event) {
 		InfoStore infoStore = InfoStore.getInstance();
 		Item currentItem = new Item(1,item.getId());
-
-		//adds the item to the list instance
-		infoStore.getList().add(currentItem);
 		
 		stage = (Stage) detailedItemGridPane.getScene().getWindow();
 		stage.close();

--- a/ShoppIt/src/main/controllers/MainController.java
+++ b/ShoppIt/src/main/controllers/MainController.java
@@ -30,7 +30,7 @@ public class MainController implements Initializable {
     public void initialize(URL arg0, ResourceBundle arg1) {
         DatabaseManager DB = new DatabaseManager();
 
-        lists = DB.getFromDatabase(ShoppingList.class, "FROM ShoppingList s");
+        lists = DB.getTable(ShoppingList.class, "ShoppingList");
 
         for (int i = 0; i < lists.size(); i++) {
             MainListView.getItems().add("List" + Integer.toString(i));

--- a/ShoppIt/src/main/controllers/SearchPopUpController.java
+++ b/ShoppIt/src/main/controllers/SearchPopUpController.java
@@ -60,7 +60,7 @@ public class SearchPopUpController implements Initializable {
 		
 		//Retrieves all food items for the database 
 		DatabaseManager databaseManager = new DatabaseManager();
-		List<FoodItem> foodItemObjects = databaseManager.getFromDatabase(FoodItem.class,"FROM FoodItem");
+		List<FoodItem> foodItemObjects = databaseManager.getTable(FoodItem.class,"FoodItem");
 
 		try {
 			for (FoodItem item : foodItemObjects) {

--- a/ShoppIt/src/main/controllers/SearchPopUpController.java
+++ b/ShoppIt/src/main/controllers/SearchPopUpController.java
@@ -60,10 +60,6 @@ public class SearchPopUpController implements Initializable {
 		
 		//Retrieves all food items for the database 
 		DatabaseManager databaseManager = new DatabaseManager();
-		// can remove these lines once the code is ran once as the database is preserved afterwards
-		databaseManager.updateImage("Carrots","carrots.png");
-		databaseManager.updateImage("Spring Onion","spring_onions.jpg");
-		databaseManager.updateImage("Mushroom","mushrooms.png");
 		List<FoodItem> foodItemObjects = databaseManager.getFromDatabase(FoodItem.class,"FROM FoodItem");
 
 		try {

--- a/ShoppIt/src/main/database/DatabaseManager.java
+++ b/ShoppIt/src/main/database/DatabaseManager.java
@@ -68,7 +68,7 @@ public class DatabaseManager {
      * @param <T>
      * @return
      */
-    public <T> List<T> getFromDatabase(Class<T> targetClass, String HQLQuery) {
+    private <T> List<T> getFromDatabase(Class<T> targetClass, String HQLQuery) {
         Transaction tx = null;
         List<T> list;
 

--- a/ShoppIt/src/main/database/DatabaseManager.java
+++ b/ShoppIt/src/main/database/DatabaseManager.java
@@ -40,6 +40,29 @@ public class DatabaseManager {
     }
 
     /**
+     * Get a table
+     * @param targetClass Class type to be returned
+     * @param tableName Table name
+     * @return List of attributes of type targetClass from table
+     * @param <T>
+     */
+    public <T> List<T> getTable(Class<T> targetClass, String tableName) {
+        return getFromDatabase(targetClass, "FROM " + tableName);
+    }
+
+    /**
+     * Get attributes from a table
+     * @param targetClass Class type to be returned
+     * @param attribute Attribute from the table
+     * @param tableName Table name
+     * @return List of attributes of type targetClass from table
+     * @param <T>
+     */
+    public <T> List<T> getAttributeList(Class<T> targetClass, String attribute, String tableName) {
+        return getFromDatabase(targetClass, "SELECT s." + attribute + " FROM " + tableName + " s");
+    }
+
+    /**
      * @param targetClass
      * @param HQLQuery    For getting all items of a particular class use "FROM classname"
      * @param <T>


### PR DESCRIPTION
Closes #100. Peer coding with @ktha423 @jzho987

- Removed unused updateImage code from previous bug fix #75 from PR #82 
- Added more specific query methods for getting table and attribute of a table.
- Made generic getFromDatabase method private to discourage using HQL queries externally.